### PR TITLE
React swap 2

### DIFF
--- a/0a_functional_programming_objectives_old.md
+++ b/0a_functional_programming_objectives_old.md
@@ -1,0 +1,28 @@
+Up to this point, we have focused on object-oriented programming. However, there are other paradigms beyond object-oriented programming. One of the most useful and popular paradigms is **functional programming**. This course section, we will focus on learning how to program using a functional approach.
+
+Having at least a basic understanding of functional programming is essential to progressing as a developer. Just as importantly, being familiar is also essential to becoming a good React developer because React is functional, not object-oriented.
+
+It's important to note that functional programming is very challenging for people at first. It is okay if you do not understand all the concepts covered in this course section. Instead, this is an opportunity to get exposure to and work towards understanding important computer programming concepts that will help you advance your career.
+
+In this course section, we'll cover the following:
+
+* Pure functions
+* First class functions
+* Higher order functions
+* Immutability
+* Closures
+* Currying functions
+* Recursion
+* Composition over inheritance
+* JavaScript methods commonly used for functional programming
+
+## Independent Project Objectives
+---
+
+For this course section, the independent project will be different from previous weeks. You will spend your normally scheduled independent project time studying for a whiteboard technical interview. Then, you will take part in a whiteboard technical interview with your peers. You will submit peer evaluations for the technical interviews you participate in and also submit your whiteboard solution in lieu of the usual independent project. More details on technical whiteboarding will be provided in this weekend's homework.
+
+This course section's group whiteboard interview will be reviewed for the following objectives:
+
+- Whiteboard solution has been submitted.
+- Whiteboard interview meets all requirements (based on peer feedback).
+- Your evaluations for peers are complete and include constructive feedback.

--- a/0a_react_with_nosql_objectives_old.md
+++ b/0a_react_with_nosql_objectives_old.md
@@ -1,0 +1,47 @@
+In this course section, we'll learn how to persist data with a NoSQL database. We'll use Google's Firebase, an app development platform that provides many services including NoSQL databases, authentication, and hosting.
+
+We will cover the following concepts about NoSQL databases:
+
+* The differences between NoSQL and SQL databases.
+* How data is saved in NoSQL database.
+* The CAP theorem, which describes distributed NoSQL databases.
+* The acronym BASE that further describes the CAP theorem.
+
+When working with Firebase, we'll use the following services and integrate them into the Help Queue project:
+* A Firestore database (a type of NoSQL database)
+* Authentication
+* Hosting
+
+In this course section, we won't be using Redux to manage our application's state. Instead, we'll learn how to use React hooks! Hooks are tools that enable us to *re*use stateful logic and to use state and lifecycle features in function components. While using hooks and using Redux is not mutually exclusive, we're going to focus on only using hooks to manage our React app's state and component lifecycle events by refactoring the Help Queue project. To that end, we'll provide a repo with a starter project.
+
+We'll cover the following topics about hooks:
+
+* The `useState()` hook
+* The `useEffect()` hook
+* The rules of hooks
+* How hooks solve multiple pain points in React development
+* How to write a custom hook
+
+After we learn how to use hooks, we will no longer use class components. That means we'll take the extra step of converting the Help Queue `TicketControl` component into a function component that uses hooks to manage state and component lifecycle events. Thereafter, we'll start adding Firebase services to the Help Queue. 
+
+We'll also cover these additional topics:
+
+* Structuring data in Firestore databases
+* Routing with React Router
+* Making Firestore queries
+* Adding a wait time to the Help Queue
+* Styling components with styled-components
+* Other further exploration activities
+
+## Independent Project Objectives
+---
+
+You will not be expected to incorporate the concepts of this section into your independent project. Instead, your next independent project will be devoted to working on your capstone project. Your code will be reviewed for the following objectives:
+
+* Project commit history demonstrates a full session of work.
+  *  For full-time students, we require 8 hours. 
+  *  For part-time students, we require 4 hours.
+* Project includes capstone proposal.
+* README includes an overview of the project.
+
+**You can preview the exact instructions and requirements for the React with NoSQL code review by reading the [React with NoSQL Independent Project](https://new.learnhowtoprogram.com/react/react-with-nosql/react-with-nosql-independent-project) lesson at the end of this section.**

--- a/5a_classwork_functional_programming_independent_project.md
+++ b/5a_classwork_functional_programming_independent_project.md
@@ -3,24 +3,39 @@
 
 Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
 
-We also suggest that you review the lessons related to whiteboarding, being an interviewer, and giving constructive feedback earlier in this course section.
-
 ## Functional Programming Project Objectives
 ---
 
-During your normally scheduled independent project time, you will prepare for your whiteboard interview session.
+This course section's independent project will be a little bit different than usual. Instead of applying your Functional JavaScript skills, you'll get a head-start on thinking about capstones. 
+
+Capstone projects will appear later down the road - after the C# course - so it's normal to not have a clear idea of exactly what technology you might implement. However, this is a great time to start thinking about what you might want your capstone project to *accomplish*. 
+
+A capstone is a project that you design and implement by yourself. In other educational sectors this may be called a thesis or a practicum. Your capstone project in this program will serve as the centerpiece of your coding portfolio that you will use in your job search. Compared to a required school project, a capstone project is more impressive to employers because it demonstrates what motivates you, your decision making skills, and your willingness to take intellectual risk. Capstone projects also tend to be more memorable because there are more opportunities to express your personality and you can plan a project around your interests. 
+
+You may have never planned a project like this before. This is why Epicodus wants to start capstone planning early. Epicodus’s goal is to give you ample time to think, get feedback, and iterate on your capstone project before the start of the Capstone course. Project planning is a skill set, separate from coding, that becomes easier with experience. However, Epicodus doesn’t really teach project planning in the program because a junior developer is not generally expected to plan entire projects from scratch. So, this code review and future code reviews will provide direction to help you plan your project. Epicodus staff are also available for feedback and guidance.
+
+During your normally scheduled independent project time, you will:
+
+* Create one, or more, idea boards
+* Create an outline explaining your chosen capstone idea, answering the following questions as a guide:
+  * Who is this program built for?
+  * What is the purpose of the program?
+  * What is your end goal for this program?
+  * Are there any roadblocks or issues you foresee with building this program?
+  * If you were asked to begin working on this program now what would you start with?
 
 Your submission will be reviewed for the following objectives:
 
-* Whiteboard solution has been submitted.
-* Whiteboard interview meets all requirements (based on peer feedback).
-* Your evaluations for peers are complete and include constructive feedback.
+* An idea board(s) to show us your thought process and what other project ideas you considered
+* Includes a one page outline of capstone project.
+
+It's alright to not stick to a specific idea if you find something more interesting, and it's alright to have more than one idea.
 
 ## Submission
 ---
 
-Your instructor will plan out when you will conduct the group whiteboard interview, which could be this week or next depending on the program you are enrolled in and other scheduling concerns. Check in with your instructor about the exact schedule, timing, and structure of this event and when your Epicenter submissions are due.
+Make sure to utilize GitHub to track the creation of your boards, and your capstone outline. Remember, you track image files, .pdf files, or whatever project file type you wish to use!
 
-After each student's whiteboard interview in your group, you will submit the feedback rubric you complete via the form available in the [_Peer Evaluations_ tab](https://epicenter.epicodus.com/peer_evaluations/new) on Epicenter. After you are finished with the entire group whiteboard interview, you will submit your whiteboard solution to the **Functional Programming with JavaScript** code review on [Epicenter](https://epicenter.epicodus.com/). 
+Submit your code for review to the **Functional Programming with JavaScript** code review on [Epicenter](https://epicenter.epicodus.com/).
 
 Visit [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) for details on how to submit, how feedback works and course completion requirements.

--- a/5a_classwork_functional_programming_independent_project_old.md
+++ b/5a_classwork_functional_programming_independent_project_old.md
@@ -1,0 +1,26 @@
+## Independent Projects Overview
+---
+
+Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
+
+We also suggest that you review the lessons related to whiteboarding, being an interviewer, and giving constructive feedback earlier in this course section.
+
+## Functional Programming Project Objectives
+---
+
+During your normally scheduled independent project time, you will prepare for your whiteboard interview session.
+
+Your submission will be reviewed for the following objectives:
+
+* Whiteboard solution has been submitted.
+* Whiteboard interview meets all requirements (based on peer feedback).
+* Your evaluations for peers are complete and include constructive feedback.
+
+## Submission
+---
+
+Your instructor will plan out when you will conduct the group whiteboard interview, which could be this week or next depending on the program you are enrolled in and other scheduling concerns. Check in with your instructor about the exact schedule, timing, and structure of this event and when your Epicenter submissions are due.
+
+After each student's whiteboard interview in your group, you will submit the feedback rubric you complete via the form available in the [_Peer Evaluations_ tab](https://epicenter.epicodus.com/peer_evaluations/new) on Epicenter. After you are finished with the entire group whiteboard interview, you will submit your whiteboard solution to the **Functional Programming with JavaScript** code review on [Epicenter](https://epicenter.epicodus.com/). 
+
+Visit [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) for details on how to submit, how feedback works and course completion requirements.

--- a/5a_classwork_react_fundamentals_independent_project_old.md
+++ b/5a_classwork_react_fundamentals_independent_project_old.md
@@ -1,0 +1,41 @@
+## Independent Projects Overview
+---
+
+Project prompts will be available on Epicenter at 8:00 am Friday for full-time students and 8:00 am on Thursday for part-time students. Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
+
+## React Fundamentals Project Objectives
+---
+
+Even though you have learned full CRUD in this section, **you will only be expected to add CREATE, READ, and UPDATE functionality for the independent project.**
+
+Your code will be reviewed for the following objectives:
+
+* Application compiles and runs without error, and warnings in the DevTools console are resolved.
+* Functional and class components are used correctly.
+* Application effectively uses local and shared state.
+* Props are used correctly and always include `PropTypes`.
+* README includes an accurate representation of the application's component tree.
+* Project is in a polished, portfolio-quality state.
+* The prompt's required functionality and baseline project requirements are in place by the deadline.
+
+### What is a polished, portfolio-quality state?
+When a project is both polished and in a portfolio-quality state, this means:
+
+* You've reviewed your project and your README prior to submitting it to make sure there are no errors or missing information and you are consistent in your indentation, spacing, and code structure. 
+* You are following the best practices and coding conventions we teach.
+
+### What are the baseline project requirements?
+All independent coding projects at Epicodus have these baseline requirements:
+
+* A complete and informative README
+* The project's commit history demonstrates that the project's required work schedule and hours have been met:
+  * 8 hours completed on Friday is required for full-time students
+  * 4 hours completed over the weekend is required for part-time students
+* Completion of the project based on the prompt _and_ objectives. The prompt contains details on the project's theme and features that are not always detailed in the objective. Carefully read through the prompt towards the end of your work session to make sure that you are not missing anything.
+
+## Submission
+---
+
+Submit your code for review to the **React Fundamentals** code review on [Epicenter](https://epicenter.epicodus.com/).
+
+Visit [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) for details on how to submit, how feedback works and course completion requirements.

--- a/5a_classwork_react_with_redux_independent_project.md
+++ b/5a_classwork_react_with_redux_independent_project.md
@@ -1,7 +1,7 @@
 ## Independent Projects Overview
 ---
 
-Project prompts will be available on Epicenter at 8:00 am Friday for full-time students and 8:00 am on Thursday for part-time students. Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
+Project prompts will be available on Epicenter at 8:00 am Friday for both full-time and part-time students. Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
 
 ## React with Redux Project Objectives
 ---

--- a/5a_react_with_apis_capstone_work_old.md
+++ b/5a_react_with_apis_capstone_work_old.md
@@ -1,0 +1,14 @@
+There is no code review to submit for this course section. Instead, you will be expected to work on your capstone which should clearly be documented in your commit history:
+
+  *  For full-time students, we require **8 hours** of work. 
+  *  For part-time students, we require **4 hours** of work. 
+
+When you turn in your capstone at the end of the program, your commit history will be checked to ensure that you put in the required work hours. 
+
+**In total, you will be expected to put at least 40 hours of work into your capstone** during the time we provide you to work on your project in class and in lieu of regular independent projects for certain course sections. If you have any questions about this, check in with your instructor.
+
+**For full-time students**, this includes the work you did for the React with Redux and React with NoSQL code reviews, the work that you do this Friday, and the work that you do during class next week. 
+
+**For part-time students**, this includes the work you did for the React with Redux and React with NoSQL code reviews, the work that you do over this coming weekend, and the work that you in the last two weeks of class dedicated to your capstone. 
+
+You are welcome to put in more work if you like. Remember that this project should be a foundational portfolio piece that can help lead to a job. Use your time wisely!

--- a/5a_react_with_nosql_independent_project_old.md
+++ b/5a_react_with_nosql_independent_project_old.md
@@ -1,0 +1,55 @@
+## Independent Projects Overview
+---
+
+Before you begin your project, make sure to take a moment to review the [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) lesson.
+
+## React with NoSQL Project Objectives
+---
+
+For this independent project, you will be continuing to work on your capstone. You will not be expected to add any objectives from this course section — however, you may choose to do so if you plan to implement a NoSQL database in your project.
+
+Over the next several weeks, you are expected to put at least 40 hours of work into your capstone during the time we provide you to work on your project in class and in lieu of regular independent projects.
+
+Here is a general breakdown of that schedule by course section:
+
+* **React with Redux**: there is no independent project prompt. Instead, you will spend this time working on your capstone.
+* **React with NoSQL**: there is no independent project prompt. Instead, you will spend this time working on your capstone.
+* **React with APIs**: there is no independent project prompt. Instead, you will spend this time working on your capstone.
+* **Independent Capstone**: this section is dedicated to working on your capstone. 
+
+This is the second session of your dedicated class time!
+
+For many of you, you will be doing continued research, learning, and planning. You might not start to code regularly until the next capstone work session, and that's entirely normal. Remember to stay focused on your MVP.
+
+Your instructor may have asked you to revise your capstone proposal and resubmit it to them. If you have not done that yet, make sure to do that first.
+
+If you are focused on continued research and planning (as opposed to starting to code), we ask that you track your activities in your README in a section called `Research & Planning Log`, like in the example below. Every time you start or finish an activity, make a note of it in the log, and commit the README to your Git history. You don’t have to follow the exact structure below, and you do not have to log your breaks. 
+
+Once you start coding and committing regularly, you don’t have to keep this log of activities, though you are welcome to. One reason to keep adding to the `Research and Planning Log` is that it can be a helpful way to track your development progress, milestones, and helpful resources you've found along the way. In turn, this can help you formulate your pitch for your project and help you pick up where you left off after a break from working on the project.
+
+```
+### Research & Planning Log
+#### Friday, 08/13
+* 8:20: prioritize to-dos
+* 8:40: research libraries for animations
+* 9:30: try out react-spring library, review docs + examples
+* 1:20: implement react-spring library in sample project
+…
+```
+
+If you are focused on continued research, keep in mind that we expect you to log your activities throughout your work session: each time you change activities, we expect that you add an item to your `Research & Planning Log` and that you commit your README to track the addition. **We will not accept a log completed in one commit at the end of your work session.**
+
+Your submission will be reviewed for the following objectives:
+
+* Project commit history demonstrates a full session of work.
+  *  For full-time students, we require 8 hours. 
+  *  For part-time students, we require 4 hours.
+* Project includes capstone proposal.
+* README includes an overview of the project.
+
+## Submission
+---
+
+Submit your code for review to the **React with NoSQL** code review on [Epicenter](https://epicenter.epicodus.com/).
+
+Visit [Independent Projects and Code Reviews](https://new.learnhowtoprogram.com/prework/getting-started-at-epicodus/independent-projects-and-code-reviews) for details on how to submit, how feedback works and course completion requirements.

--- a/layouts/ft_old/ft_old_1_functional-programming-with-javascript.yaml
+++ b/layouts/ft_old/ft_old_1_functional-programming-with-javascript.yaml
@@ -4,7 +4,7 @@ repo: react-full-stack
 directory: 2_functional-programming-with-javascript
 lessons:
   - title: Functional Programming with JavaScript Objectives
-    filename: 0a_functional_programming_objectives.md
+    filename: 0a_functional_programming_objectives_old.md
     day: weekend
     type: lesson
   - title: Introduction to Functional Programming
@@ -164,6 +164,6 @@ lessons:
     type: exercise
     repo: career-services-full-stack
   - title: Functional Programming with JavaScript Independent Project
-    filename: 5a_classwork_functional_programming_independent_project.md
+    filename: 5a_classwork_functional_programming_independent_project_old.md
     day: friday
     type: exercise

--- a/layouts/ft_old/ft_old_2_react-fundamentals.yaml
+++ b/layouts/ft_old/ft_old_2_react-fundamentals.yaml
@@ -183,6 +183,6 @@ lessons:
     type: lesson
     repo: career-services-full-stack
   - title: React Fundamentals Independent Project
-    filename: 5a_classwork_react_fundamentals_independent_project.md
+    filename: 5a_classwork_react_fundamentals_independent_project_old.md
     day: friday
     type: exercise

--- a/layouts/ft_old/ft_old_4_react-with-nosql.yaml
+++ b/layouts/ft_old/ft_old_4_react-with-nosql.yaml
@@ -4,7 +4,7 @@ repo: react-full-stack
 directory: 5_react-with-nosql
 lessons:
   - title: React with NoSQL Objectives
-    filename: 0a_react_with_nosql_objectives.md
+    filename: 0a_react_with_nosql_objectives_old.md
     day: weekend
     type: lesson
   - title: Introduction to Hooks with the useState Hook
@@ -137,6 +137,6 @@ lessons:
     type: exercise
     repo: career-services-full-stack
   - title: React with NoSQL Independent Project
-    filename: 5a_react_with_nosql_independent_project.md
+    filename: 5a_react_with_nosql_independent_project_old.md
     day: friday
     type: exercise

--- a/layouts/pt/pt_10_react-with-apis-part-2.yaml
+++ b/layouts/pt/pt_10_react-with-apis-part-2.yaml
@@ -5,37 +5,37 @@ directory: 11_react-with-apis-part-2
 lessons:
   - title: React with API (Multi-Week Project)
     filename: 1a_classwork_react_with_api_three_day_project.md
-    day: sunday
+    day: monday
     type: exercise
   - title: 'Further Exploration: Creating a Custom React Environment'
     filename: 2a_further_exploration_creating_our_own_react_environment.md
-    day: sunday
+    day: monday
     type: lesson
   - title: 'Further Exploration: Data Visualization'
     filename: 2b_further_exploration_data_visualization.md
-    day: sunday
+    day: monday
     type: lesson
   - title: 'Further Exploration: Animations with React'
     filename: 2c_further_exploration_ui_animations_and_interactivity.md
-    day: sunday
-    type: lesson
-  - title: React with API (Multi-Week Project)
-    filename: 1a_classwork_react_with_api_three_day_project.md
     day: monday
-    type: exercise
+    type: lesson
   - title: React with API (Multi-Week Project)
     filename: 1a_classwork_react_with_api_three_day_project.md
     day: tuesday
     type: exercise
-  - title: 'Technical Interview Practice: APIs and Further Exploration'
-    filename: 3a_technical_interview_practice_apis_and_further_exploration_classwork.md
-    day: wednesday
-    type: exercise
   - title: React with API (Multi-Week Project)
     filename: 1a_classwork_react_with_api_three_day_project.md
     day: wednesday
     type: exercise
+  - title: 'Technical Interview Practice: APIs and Further Exploration'
+    filename: 3a_technical_interview_practice_apis_and_further_exploration_classwork.md
+    day: thursday
+    type: exercise
+  - title: React with API (Multi-Week Project)
+    filename: 1a_classwork_react_with_api_three_day_project.md
+    day: thursday
+    type: exercise
   - title: Continued Work on your Capstone
     filename: 5a_react_with_apis_capstone_work.md
-    day: thursday
+    day: friday
     type: lesson

--- a/layouts/pt/pt_11_team-week.yaml
+++ b/layouts/pt/pt_11_team-week.yaml
@@ -40,16 +40,16 @@ lessons:
     repo: shared-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: Pull Requests with Branches
     filename: pull_requests_with_branches.md
-    day: sunday
+    day: monday
     type: lesson
     repo: shared-full-stack
   - title: Pull Requests with Forks
     filename: pull_requests_with_forks.md
-    day: monday
+    day: tuesday
     type: lesson
     repo: shared-full-stack

--- a/layouts/pt/pt_12_team-week-part-2.yaml
+++ b/layouts/pt/pt_12_team-week-part-2.yaml
@@ -10,6 +10,6 @@ lessons:
     repo: shared-full-stack
   - title: Team Week Presentations and Code Review
     filename: team_week_presentations_and_code_review.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: shared-full-stack

--- a/layouts/pt/pt_1_functional-programming-with-javascript.yaml
+++ b/layouts/pt/pt_1_functional-programming-with-javascript.yaml
@@ -87,85 +87,85 @@ lessons:
     repo: career-services-full-stack
   - title: 'Journal #7 Discussion'
     filename: 2_week_seven_journal_discussion_classwork.md
-    day: sunday
+    day: monday
     type: exercise
     repo: career-services-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: Coin Counter, Sieve
     filename: 1a_classwork_coin_counter_sieve.md
-    day: sunday
+    day: monday
     type: exercise
   - title: 'Whiteboard Practice: Closures'
     filename: 1b_classwork_whiteboard_closure_practice.md
-    day: sunday
+    day: monday
     type: exercise
   - title: 'Whiteboard Practice: Recursion'
     filename: 1c_classwork_whiteboard_recursion_practice.md
-    day: sunday
+    day: monday
     type: exercise
   - title: The Problems of Classical Inheritance
     filename: 0h_the_problems_of_classical_inheritance.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Spread Operator
     filename: 0i_spread_operator.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Composition
     filename: 0k_composition.md
-    day: sunday
+    day: monday
     type: lesson
   - title: State
     filename: 0ka_state.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Storing State in Closures
     filename: 0kb_storing_state_in_closures.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Building a Functional Application (Part 1)
     filename: 0l_building_a_functional_application.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Building a Functional Application (Part 2)
     filename: 0m_building_a_functional_application_part_2.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Power Plant, Project Euler (Two-day Project)
     filename: 2a_classwork_power_plant_project_euler.md
-    day: monday
+    day: tuesday
     type: exercise
   - title: 'Whiteboard Practice: Composition'
     filename: 2b_classwork_whiteboard_composition.md
-    day: monday
+    day: tuesday
     type: exercise
   - title: Power Plant, Project Euler (Two-day Project)
     filename: 2a_classwork_power_plant_project_euler.md
-    day: tuesday
+    day: wednesday
     type: exercise
   - title: 'Whiteboard Practice: Composition'
     filename: 2b_classwork_whiteboard_composition.md
-    day: tuesday
+    day: wednesday
     type: exercise
   - title: 'Further Exploration: Creating Deep Clones'
     filename: 0ia_creating_deep_clones.md
-    day: tuesday
+    day: wednesday
     type: lesson
   - title: Epicodus Job Board
     filename: epicodus_job_board_classwork.md
-    day: wednesday
+    day: thursday
     type: exercise
     repo: career-services-full-stack
   - title: 'Technical Interview Preparation: Functional Programming'
     filename: 4a_classwork_technical_interview_prep_functional_programming.md
-    day: wednesday
+    day: thursday
     type: exercise
   - title: Addressing Implicit Bias
     filename: addressing_implicit_bias.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: DEI-full-stack

--- a/layouts/pt/pt_2_functional-programming-with-javascript-part-2.yaml
+++ b/layouts/pt/pt_2_functional-programming-with-javascript-part-2.yaml
@@ -5,14 +5,10 @@ directory: 3_functional-programming-with-javascript-part-2
 lessons:
   - title: Build Your Own RPG, Haiku Checker (Multi-day Project)
     filename: 3a_classwork_rpg_haiku_checker.md
-    day: sunday
+    day: monday
     type: exercise
   - title: 'Whiteboard Practice: Project Euler'
     filename: 3b_classwork_whiteboard_project_euler.md
-    day: sunday
-    type: exercise
-  - title: Build Your Own RPG, Haiku Checker (Multi-day Project)
-    filename: 3a_classwork_rpg_haiku_checker.md
     day: monday
     type: exercise
   - title: Build Your Own RPG, Haiku Checker (Multi-day Project)
@@ -23,7 +19,11 @@ lessons:
     filename: 3a_classwork_rpg_haiku_checker.md
     day: wednesday
     type: exercise
+  - title: Build Your Own RPG, Haiku Checker (Multi-day Project)
+    filename: 3a_classwork_rpg_haiku_checker.md
+    day: thursday
+    type: exercise
   - title: Functional Programming with JavaScript Independent Project
     filename: 5a_classwork_functional_programming_independent_project.md
-    day: thursday
+    day: friday
     type: exercise

--- a/layouts/pt/pt_3_react-fundamentals.yaml
+++ b/layouts/pt/pt_3_react-fundamentals.yaml
@@ -70,91 +70,91 @@ lessons:
     repo: career-services-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: 'Journal #14 Discussion'
     filename: 2_week_16_discussion_classwork.md
-    day: sunday
+    day: monday
     type: exercise
     repo: career-services-full-stack
   - title: Help Queue, Social Media, Airbnb Clone
     filename: 1a_classwork_help_queue_social_media_airbnb_clone.md
-    day: sunday
+    day: monday
     type: exercise
   - title: Introduction to State
     filename: 1b_introduction_to_state.md
-    day: sunday
+    day: monday
     type: lesson
   - title: 'Planning Our Application: Part 2'
     filename: 1c_planning_our_application_part_2.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Adding Local State
     filename: 1d_adding_local_state.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Conditional Rendering
     filename: 1e_conditional_rendering.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Updating State with Events
     filename: 1f_updating_state_with_events.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Binding Functions in React
     filename: 1g_binding_functions_in_react.md
-    day: sunday
-    type: lesson
-  - title: Farmers Market (Two-day Project)
-    filename: 2a_classwork_css_practice_farmers_markets.md
     day: monday
-    type: exercise
+    type: lesson
   - title: Farmers Market (Two-day Project)
     filename: 2a_classwork_css_practice_farmers_markets.md
     day: tuesday
     type: exercise
+  - title: Farmers Market (Two-day Project)
+    filename: 2a_classwork_css_practice_farmers_markets.md
+    day: wednesday
+    type: exercise
   - title: Applying for Jobs
     filename: classwork_applying_for_jobs.md
-    day: wednesday
+    day: thursday
     type: exercise
     repo: career-services-full-stack
   - title: 'Technical Interview Preparation: React Fundamentals'
     filename: 4b_classwork_technical_interview_prep_react_fundamentals.md
-    day: wednesday
+    day: thursday
     type: exercise
   - title: Following Up During the Job Application Process
     filename: 6_Follow-Up_During_the_Job_Application_Process.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack
   - title: Expand Your Job Search Network Through Cold Emailing
     filename: 7_Expand_your_Job_Search_Network_through_Cold_Emailing.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack
   - title: Tools for Email Management
     filename: 8_Tools_for_Email_Management.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack
   - title: UUID Library
     filename: 2ab_uuid_library.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Adding a Form
     filename: 2b_adding_a_form.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Unidirectional Data Flow
     filename: 2c_unidirectional_data_flow.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Passing Data Via Callbacks
     filename: 2d_passing_data_via_callbacks.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: 'Styling React: CSS Objects'
     filename: 2e_styling_react_css_objects.md
-    day: wednesday
+    day: thursday
     type: lesson

--- a/layouts/pt/pt_4_react-fundamentals-part-2.yaml
+++ b/layouts/pt/pt_4_react-fundamentals-part-2.yaml
@@ -5,40 +5,36 @@ directory: 5_react-fundamentals-part-2
 lessons:
   - title: Help Queue, Merch Site, Event Logger (Multi-day Project)
     filename: 3a_classwork_help_queue_merch_site_event_logger_two_day.md
-    day: sunday
+    day: monday
     type: exercise
   - title: 'Overview of Next Steps: Adding READ, UPDATE, and DELETE Functionality'
-    filename: 3ab_wednesday_homework_preface.md
-    day: sunday
+    filename: 3ab_thursday_homework_preface.md
+    day: monday
     type: lesson
   - title: 'Planning Our Application: Part 3'
     filename: 3b_planning_our_application_part_3.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Using JSX Expressions with Arguments
     filename: 3c_using_jsx_expressions_with_arguments.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Showing Ticket Detail
     filename: 3d_showing_ticket_detail.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Deleting a Ticket
     filename: 3e_deleting_a_ticket.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Reusing Components
     filename: 3f_reusing_components.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Updating a Ticket
     filename: 3g_updating_a_ticket.md
-    day: sunday
-    type: lesson
-  - title: Help Queue, Merch Site, Event Logger (Multi-day Project)
-    filename: 3a_classwork_help_queue_merch_site_event_logger_two_day.md
     day: monday
-    type: exercise
+    type: lesson
   - title: Help Queue, Merch Site, Event Logger (Multi-day Project)
     filename: 3a_classwork_help_queue_merch_site_event_logger_two_day.md
     day: tuesday
@@ -47,7 +43,11 @@ lessons:
     filename: 3a_classwork_help_queue_merch_site_event_logger_two_day.md
     day: wednesday
     type: exercise
+  - title: Help Queue, Merch Site, Event Logger (Multi-day Project)
+    filename: 3a_classwork_help_queue_merch_site_event_logger_two_day.md
+    day: thursday
+    type: exercise
   - title: React Fundamentals Independent Project
     filename: 5a_classwork_react_fundamentals_independent_project.md
-    day: thursday
+    day: friday
     type: exercise

--- a/layouts/pt/pt_5_react-with-redux.yaml
+++ b/layouts/pt/pt_5_react-with-redux.yaml
@@ -66,57 +66,57 @@ lessons:
     repo: career-services-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: 'Journal #15 Discussion'
     filename: 2_week_17_discussion_classwork.md
-    day: sunday
+    day: monday
     type: exercise
     repo: career-services-full-stack
   - title: Redux Help Queue, Project Refactor
     filename: 1a_classwork_redux_help_queue_project_refactor.md
-    day: sunday
+    day: monday
     type: exercise
   - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
     filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
-    day: monday
+    day: tuesday
     type: exercise
   - title: Combining Redux Reducers
     filename: 1b_combining_reducers_in_redux.md
-    day: monday
+    day: tuesday
     type: lesson
   - title: Adding Combined Reducers to React
     filename: 1c_adding_our_combined_reducer_to_react.md
-    day: monday
+    day: tuesday
     type: lesson
   - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
     filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
-    day: tuesday
+    day: wednesday
     type: exercise
   - title: Building a React Application with Redux From Scratch
     filename: 1d_building_a_react_redux_application_ground_up.md
-    day: tuesday
+    day: wednesday
     type: lesson
   - title: Applying for Jobs
     filename: classwork_applying_for_jobs.md
-    day: wednesday
+    day: thursday
     type: exercise
     repo: career-services-full-stack
   - title: 'Technical Interview Practice: React and Redux'
     filename: 4a_technical_interview_practice_react_and_redux.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Action Creators
     filename: 2b_action_creators.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Action Constants
     filename: 2c_action_constants.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Understanding Stereotype Threat
     filename: understanding_stereotype_threat.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: DEI-full-stack

--- a/layouts/pt/pt_6_react-with-redux-part-2.yaml
+++ b/layouts/pt/pt_6_react-with-redux-part-2.yaml
@@ -5,28 +5,24 @@ directory: 7_react-with-redux-part-2
 lessons:
   - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
     filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
-    day: sunday
+    day: monday
     type: exercise
   - title: Introduction to date-fns
     filename: 3b_introduction_to_datefns.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Component Lifecycle Methods
     filename: 3c_component_lifecycle_and_methods.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Adding Wait Time to the Queue
     filename: 3d_adding_wait_time_to_the_queue.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Adding Wait Time to the Queue Part 2
     filename: 3e_adding_wait_time_to_the_queue_part_2.md
-    day: sunday
-    type: lesson
-  - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
-    filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
     day: monday
-    type: exercise
+    type: lesson
   - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
     filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
     day: tuesday
@@ -35,7 +31,11 @@ lessons:
     filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
     day: wednesday
     type: exercise
+  - title: Forum, Word Puzzle, Tic Tac Toe (Multi-Day Project)
+    filename: 2a_classwork_redux_forum_hangman_tic_tac_toe_three_day_project.md
+    day: thursday
+    type: exercise
   - title: React with Redux Independent Project
     filename: 5a_classwork_react_with_redux_independent_project.md
-    day: thursday
+    day: friday
     type: exercise

--- a/layouts/pt/pt_7_react-with-nosql.yaml
+++ b/layouts/pt/pt_7_react-with-nosql.yaml
@@ -70,60 +70,60 @@ lessons:
     repo: career-services-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: 'Journal #16 Discussion'
     filename: 2_week_18_discussion_classwork.md
-    day: sunday
+    day: monday
     type: exercise
     repo: career-services-full-stack
   - title: Firestore Survey, Quiz of Choice (Three-Day Project) - Part 1
     filename: 1a_classwork_firestore_survey_quiz_of_choice.md
-    day: sunday
+    day: monday
     type: exercise
   - title: Client-Side Routing
     filename: 1b_client_side_routing.md
-    day: sunday
+    day: monday
     type: lesson
   - title: React Router
     filename: 1c_react_router.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Firebase Authentication
     filename: 1d_firebase_authentication.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Firebase Authorization
     filename: 1e_firebase_authorization.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Firestore Survey, Quiz of Choice (Three-Day Project) - Part 2
     filename: 1a_classwork_firestore_survey_quiz_of_choice_2.md
-    day: monday
+    day: tuesday
     type: exercise
   - title: Firestore Survey, Quiz of Choice (Three-Day Project) - Part 3
     filename: 1a_classwork_firestore_survey_quiz_of_choice_3.md
-    day: tuesday
+    day: wednesday
     type: exercise
   - title: Applying for Jobs
     filename: classwork_applying_for_jobs.md
-    day: wednesday
+    day: thursday
     type: exercise
     repo: career-services-full-stack
   - title: 'Technical Interview Practice: NoSQL'
     filename: 4a_technical_interview_practice_nosql_classwork.md
-    day: wednesday
+    day: thursday
     type: exercise
   - title: Firestore Queries
     filename: 2a_firestore_queries.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Adding Wait Time to the Queue
     filename: 2b_adding_wait_time_to_the_queue.md
-    day: wednesday
+    day: thursday
     type: lesson
   - title: Hosting with Firebase
     filename: 2c_hosting_with_firebase.md
-    day: wednesday
+    day: thursday
     type: lesson

--- a/layouts/pt/pt_8_react-with-nosql-part-2.yaml
+++ b/layouts/pt/pt_8_react-with-nosql-part-2.yaml
@@ -5,25 +5,29 @@ directory: 9_react-with-nosql-part-2
 lessons:
   - title: Choose Your Own Adventure (One-Week Project) - Part 1
     filename: 3a_classwork_choose_your_own_adventure.md
-    day: sunday
+    day: monday
     type: exercise
   - title: Styled Components
     filename: 3b_styled_components.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Further Exploration Opportunities
     filename: 3c_further_exploration_with_firebase.md
-    day: sunday
+    day: monday
     type: lesson
   - title: Choose Your Own Adventure (One-Week Project) - Part 2
-    filename: 3a_classwork_choose_your_own_adventure_2.md
-    day: tuesday
+    filename: 3a_classwork_choose_your_own_adventure.md
+    day: monday
     type: exercise
   - title: Choose Your Own Adventure (One-Week Project) - Part 3
-    filename: 3a_classwork_choose_your_own_adventure_3.md
+    filename: 3a_classwork_choose_your_own_adventure_2.md
     day: wednesday
+    type: exercise
+  - title: Choose Your Own Adventure (One-Week Project) - Part 4
+    filename: 3a_classwork_choose_your_own_adventure_3.md
+    day: thursday
     type: exercise
   - title: React with NoSQL Independent Project
     filename: 5a_react_with_nosql_independent_project.md
-    day: thursday
+    day: friday
     type: exercise

--- a/layouts/pt/pt_9_react-with-apis.yaml
+++ b/layouts/pt/pt_9_react-with-apis.yaml
@@ -59,47 +59,51 @@ lessons:
     repo: career-services-full-stack
   - title: Prior Course Section Survey
     filename: course_section_survey.md
-    day: sunday
+    day: monday
     type: lesson
     repo: pre-work-full-stack
   - title: 'Journal #17 Discussion'
     filename: 2_week_19_discussion_classwork.md
-    day: sunday
+    day: monday
     type: exercise
     repo: career-services-full-stack
-  - title: React with API (Multi-Week Project)
-    filename: 1a_classwork_react_with_api_three_day_project.md
-    day: sunday
-    type: exercise
-  - title: 'Further Exploration: React Native'
-    filename: 1b_further_exploration_react_native.md
-    day: sunday
-    type: lesson
-  - title: 'Further Exploration: SEO with React'
-    filename: 1c_further_exploration_seo_with_react.md
-    day: sunday
-    type: lesson
   - title: React with API (Multi-Week Project)
     filename: 1a_classwork_react_with_api_three_day_project.md
     day: monday
     type: exercise
+  - title: 'Further Exploration: React Native'
+    filename: 1b_further_exploration_react_native.md
+    day: monday
+    type: lesson
+  - title: 'Further Exploration: SEO with React'
+    filename: 1c_further_exploration_seo_with_react.md
+    day: monday
+    type: lesson
+  - title: React with API (Multi-Week Project)
+    filename: 1a_classwork_react_with_api_three_day_project.md
+    day: tuesday
+    type: exercise
+  - title: React with API (Multi-Week Project)
+    filename: 1a_classwork_react_with_api_three_day_project.md
+    day: wednesday
+    type: exercise
   - title: Applying for Jobs
     filename: classwork_applying_for_jobs.md
-    day: wednesday
+    day: thursday
     type: exercise
     repo: career-services-full-stack
   - title: Following Up During the Job Application Process
     filename: 6_Follow-Up_During_the_Job_Application_Process.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack
   - title: Expand Your Job Search Network Through Cold Emailing
     filename: 7_Expand_your_Job_Search_Network_through_Cold_Emailing.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack
   - title: Tools for Email Management
     filename: 8_Tools_for_Email_Management.md
-    day: wednesday
+    day: thursday
     type: lesson
     repo: career-services-full-stack

--- a/layouts/pt_old/pt_old_1_functional-programming-with-javascript-1e75b6d0-055f-43e6-9f66-7a959ffc3f78.yaml
+++ b/layouts/pt_old/pt_old_1_functional-programming-with-javascript-1e75b6d0-055f-43e6-9f66-7a959ffc3f78.yaml
@@ -4,7 +4,7 @@ repo: react-full-stack
 directory: 2_functional-programming-with-javascript-1e75b6d0-055f-43e6-9f66-7a959ffc3f78
 lessons:
   - title: Functional Programming with JavaScript Objectives
-    filename: 0a_functional_programming_objectives.md
+    filename: 0a_functional_programming_objectives_old.md
     day: weekend
     type: lesson
   - title: Introduction to Functional Programming

--- a/layouts/pt_old/pt_old_2_functional-programming-with-javascript-part-2.yaml
+++ b/layouts/pt_old/pt_old_2_functional-programming-with-javascript-part-2.yaml
@@ -24,6 +24,6 @@ lessons:
     day: wednesday
     type: exercise
   - title: Functional Programming with JavaScript Independent Project
-    filename: 5a_classwork_functional_programming_independent_project.md
+    filename: 5a_classwork_functional_programming_independent_project_old.md
     day: thursday
     type: exercise

--- a/layouts/pt_old/pt_old_4_react-fundamentals-part-2.yaml
+++ b/layouts/pt_old/pt_old_4_react-fundamentals-part-2.yaml
@@ -48,6 +48,6 @@ lessons:
     day: wednesday
     type: exercise
   - title: React Fundamentals Independent Project
-    filename: 5a_classwork_react_fundamentals_independent_project.md
+    filename: 5a_classwork_react_fundamentals_independent_project_old.md
     day: thursday
     type: exercise

--- a/layouts/pt_old/pt_old_7_react-with-nosql.yaml
+++ b/layouts/pt_old/pt_old_7_react-with-nosql.yaml
@@ -4,7 +4,7 @@ repo: react-full-stack
 directory: 8_react-with-nosql
 lessons:
   - title: React with NoSQL Objectives
-    filename: 0a_react_with_nosql_objectives.md
+    filename: 0a_react_with_nosql_objectives_old.md
     day: weekend
     type: lesson
   - title: Introduction to Hooks with the useState Hook

--- a/layouts/pt_old/pt_old_8_react-with-nosql-part-2.yaml
+++ b/layouts/pt_old/pt_old_8_react-with-nosql-part-2.yaml
@@ -24,6 +24,6 @@ lessons:
     day: wednesday
     type: exercise
   - title: React with NoSQL Independent Project
-    filename: 5a_react_with_nosql_independent_project.md
+    filename: 5a_react_with_nosql_independent_project_old.md
     day: thursday
     type: exercise

--- a/layouts/pt_old/pt_old_9_react-with-apis.yaml
+++ b/layouts/pt_old/pt_old_9_react-with-apis.yaml
@@ -82,6 +82,10 @@ lessons:
     filename: 1a_classwork_react_with_api_three_day_project_old.md
     day: monday
     type: exercise
+  - title: React with API (Multi-Week Project)
+    filename: 1a_classwork_react_with_api_three_day_project_old.md
+    day: tuesday
+    type: exercise
   - title: Applying for Jobs
     filename: classwork_applying_for_jobs.md
     day: wednesday


### PR DESCRIPTION
- Create duplicates of React CR lessons that need to change for the React Swap
- Add _old to versions of these duplicates that need to persist for old tracks
- Update .yaml file layouts to adhere to these changes
- Add correct information to `5a_classwork_functional_programming_independent_project.md` in reference to the updated CR listed here: [link](https://docs.google.com/document/d/1TfsN-EImI2aTrmh8EJLZJvXCt-AMEXnFoi9mJnL7xFI/edit)
- Fix residual short week layouts for pt and pt_old in react with APIs
- Update objective lessons to remove reference to inaccurate part-time schedule, copy originals and make them _old and update reference for _old stacks.