### PR TITLE
Change variable name from "throw" to "toss"

### DIFF
--- a/2b_classwork_whiteboard_composition.md
+++ b/2b_classwork_whiteboard_composition.md
@@ -32,13 +32,13 @@ Compose a function called `sound()`. You should be able to add the following fun
 
 #### Problem #3
 
-Compose a function called `throw()`. The `throw()` function should determine the `distance` and `speed` a battle robot can throw a spear. This function should be unary, so you will need to use currying.
+Compose a function called `toss()`. The `toss()` function should determine the `distance` and `speed` a battle robot can toss a spear. This function should be unary, so you will need to use currying.
 
-Next, add the `throw()` function to multiple battle robots. A result might look something like this:
+Next, add the `toss()` function to multiple battle robots. A result might look something like this:
 
 ```js
-> battleRobot1.throw();
-"The battle robot throws the spear 100 yards at 200 miles per hour!"
+> battleRobot1.toss();
+"The battle robot tosses the spear 100 yards at 200 miles per hour!"
 ```
 
 #### Problem #4


### PR DESCRIPTION
## Description
Changes the example function from having a name of "throw" to having a name of "toss"

## Motivation and Context
"throw" is a reserved word in JavaScript, so trying to create a function or a variable with the name "throw" will lead to some errors.
Fixes [this issue](https://github.com/epicodus-curriculum/javascript-full-stack/issues/27)

## How Has This Been Tested?
To verify that "throw" was not a valid name for a function or variable, I created a plain JavaScript file with following code:
```js
const throw = () =>"hello"

throw()
```

And upon running the code with node, I received this error:

```
const throw = () =>"hello"
      ^^^^^

SyntaxError: Unexpected token 'throw'

```

In addition to the errors in my terminal, the [VSCode JavaScript/TypeScript plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next) also warned me with this error: `'throw' is not allowed as a variable declaration name.`
